### PR TITLE
[BUGFIX] backendUrl may already have a querystring

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -119,7 +119,9 @@ _Shariff.prototype = {
 
     // returns shareCounts of document
     getShares: function() {
-        return $.getJSON(this.options.backendUrl + '?url=' + encodeURIComponent(this.getURL()));
+        var baseUrl = this.options.backendUrl;
+	    baseUrl += baseUrl.indexOf('?') ? '&' : '?';
+        return $.getJSON(baseUrl + 'url=' + encodeURIComponent(this.getURL()));
     },
 
     // add value of shares for each service


### PR DESCRIPTION
data-backend-url might already contain a query string. Hence it is wrong to always append ?url.
This patch handles the situation properly and adjusts to &url if necessary.